### PR TITLE
TA Homepage - removed Office closure notice for 23 Dec 2024 to 1 Jan 2025 

### DIFF
--- a/index.md
+++ b/index.md
@@ -7,8 +7,7 @@ description: Tax Academy of Singapore is a not-for-profit institution set up by
   PricewaterhouseCoopers, the Institute of Singapore Chartered Accountants and
   the Law Society of Singapore
 permalink: /
-notification: Please note that our office will be closed from 23 Dec 2024 to 1
-  Jan 2025. <br>You may wish to refer to the respective pages on this website
+notification: <br>You may wish to refer to the respective pages on this website
   for latest updates on our programmes. For enquiries, please contact us via <a
   href="https://form.gov.sg/#!/5d2c51283703d80011e52615">Enquiries and Feedback
   Form.</a>

--- a/index.md
+++ b/index.md
@@ -40,8 +40,7 @@ sections:
           announcement: The 6-day (24 Feb to 1 Mar 2025) programme, led by Prof Kees van
             Raad, Chairman, International Tax Center Leiden, is customised for
             tax professionals who are seeking to deepen their insight and
-            expertise in tax treaties. Enjoy 10% Early Bird discount if you
-            register before 24 Dec 2024!
+            expertise in tax treaties.
           link_text: Brochure details
           link_url: https://www.taxacademy.sg/files/2025ATTbrochure_website.pdf
   - infopic:

--- a/index.md
+++ b/index.md
@@ -7,8 +7,8 @@ description: Tax Academy of Singapore is a not-for-profit institution set up by
   PricewaterhouseCoopers, the Institute of Singapore Chartered Accountants and
   the Law Society of Singapore
 permalink: /
-notification: You may wish to refer to the respective pages on this website for
-  latest updates on our programmes. For enquiries, please contact us via <a
+notification: <br>You may wish to refer to the respective pages on this website
+  for latest updates on our programmes. For enquiries, please contact us via <a
   href="https://form.gov.sg/#!/5d2c51283703d80011e52615">Enquiries and Feedback
   Form.</a>
 sections:

--- a/index.md
+++ b/index.md
@@ -7,8 +7,8 @@ description: Tax Academy of Singapore is a not-for-profit institution set up by
   PricewaterhouseCoopers, the Institute of Singapore Chartered Accountants and
   the Law Society of Singapore
 permalink: /
-notification: <br>You may wish to refer to the respective pages on this website
-  for latest updates on our programmes. For enquiries, please contact us via <a
+notification: You may wish to refer to the respective pages on this website for
+  latest updates on our programmes. For enquiries, please contact us via <a
   href="https://form.gov.sg/#!/5d2c51283703d80011e52615">Enquiries and Feedback
   Form.</a>
 sections:


### PR DESCRIPTION
Hi Eunice, your request to remove the following on TA website homepage is done.

[Please note that our office will be closed from 23 Dec 2024 to 1 Jan 2025.]

Thanks!
